### PR TITLE
[ Router.ts > Route ] URLメソッドのバグを修正。

### DIFF
--- a/Router.ts
+++ b/Router.ts
@@ -50,7 +50,7 @@ export class Route {
      */
     URL(...urls: String[]): String[] | Promise<Route> {
 
-        if(!urls) return this.#URL
+        if(!urls.length) return this.#URL;
 
         this.#URL = urls;
         return new Promise((resolve)=>resolve(this));


### PR DESCRIPTION
URLメソッドにおいて、引数を何も指定しなかった場合に、配列を正しく返せていなかった問題を修正。